### PR TITLE
path.join() l:20 staticConfig.js

### DIFF
--- a/src/configs/staticConfig.js
+++ b/src/configs/staticConfig.js
@@ -17,7 +17,7 @@ async function staticConfig(config) {
         default: '.',
       },
     ]);
-  baseConfig.builds[0].src = path.join(answers.directory, '*');
+  baseConfig.builds[0].src = path.join(answers.directory, '*').replace(/\\/g, '/');
   return {
     ...config,
     ...baseConfig,


### PR DESCRIPTION
on windows using bash termainl

- without `.replace(/\\/g, '/')`

![image](https://user-images.githubusercontent.com/66258652/140176800-5d485af7-b1fc-466d-af8c-d4da058128a1.png)

- using `.replace(/\\/g, '/')` worked

![image](https://user-images.githubusercontent.com/66258652/140176952-e7eec923-0b01-45cf-9236-499d9dc57216.png)
